### PR TITLE
fix: Consistent node version as apiofjam

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18
+FROM node:18.15
 ENV XDG_CONFIG_HOME /github/workspace
 ENV WRANGLER_HOME /github/workspace
 


### PR DESCRIPTION
Fixes this node version mismatch: https://github.com/Strawberry-Jam-Manufacturers/apiofjam/actions/runs/6304104533/job/17115493472#step:6:271

Related to this PR: https://github.com/Strawberry-Jam-Manufacturers/apiofjam/pull/5700
